### PR TITLE
feat: Pg, PaymentMethod 추론가능한 타입 부여

### DIFF
--- a/PaymentMethod.ts
+++ b/PaymentMethod.ts
@@ -1,0 +1,26 @@
+/** @see https://developers.portone.io/docs/ko/sdk/javascript-sdk/payrq */
+export type PaymentMethod =
+  | 'card' // 신용카드
+  | 'trans' // 실시간계좌이체
+  | 'vbank' // 가상계좌
+  | 'phone' // 휴대폰소액결제
+  | 'paypal' // 페이팔 SPB 일반결제
+  | 'applepay' // 애플페이
+  | 'naverpay' // 네이버페이
+  | 'samsung' // 삼성페이
+  | 'kpay' // KPay앱
+  | 'kakaopay' // 카카오페이
+  | 'payco' // 페이코
+  | 'lpay' // LPAY
+  | 'ssgpay' // SSG페이
+  | 'tosspay' // 토스간편결제
+  | 'cultureland' // 문화상품권
+  | 'smartculture' // 스마트문상
+  | 'happymoney' // 해피머니
+  | 'booknlife' // 도서문화상품권
+  | 'point' // 베네피아 포인트 등 포인트 결제
+  | 'wechat' // 위쳇페이
+  | 'alipay' // 알리페이
+  | 'unionpay' // 유니온페이
+  | 'tenpay' // 텐페이
+  | (string & {});

--- a/Pg.ts
+++ b/Pg.ts
@@ -1,0 +1,32 @@
+/** @see https://developers.portone.io/docs/ko/sdk/javascript-sdk/payrq */
+export type Pg =
+  | 'html5_inicis' // 이니시스웹표준
+  | 'inicis_unified' // 이니시스 통합인증
+  | 'inicis' // 이니시스 ActiveX결제창 or API 방식
+  | 'kcp' // NHN KCP
+  | 'kcp_billing' // NHN KCP 정기결제
+  | 'uplus' // 토스페이먼츠(구 LG U+)
+  | 'tosspayments' // 토스페이먼츠 신모듈
+  | 'nice' // 나이스페이
+  | 'jtnet' // JTNet
+  | 'kicc' // 한국정보통신
+  | 'bluewalnut' // 블루월넛
+  | 'kakaopay' // 카카오페이
+  | 'danal' // 다날휴대폰소액결제
+  | 'danal_tpay' // 다날일반결제
+  | 'mobilians' // 모빌리언스 휴대폰소액결제
+  | 'chai' // 차이 간편결제
+  | 'syrup' // 시럽페이
+  | 'payco' // 페이코
+  | 'paypal' // 페이팔
+  | 'eximbay' // 엑심베이
+  | 'naverpay' // 네이버페이-결제형
+  | 'naverco' // 네이버페이-주문형
+  | 'smilepay' // 스마일페이
+  | 'daou' // 키움페이(구 페이조아)
+  | 'paymentwall' // 페이먼트월
+  | 'eximbay' // 엑심베이
+  | 'tosspay' // 토스간편결제
+  | 'smartro' // 스마트로
+  | 'settle' // 세틀뱅크
+  | (string & {});

--- a/RequestPayParams.ts
+++ b/RequestPayParams.ts
@@ -1,3 +1,5 @@
+import { PaymentMethod } from './PaymentMethod';
+import { Pg } from './Pg';
 import { RequestPayNaverAdditionalParams } from './RequestPayNaverParams';
 
 export interface RequestPayAdditionalParams {
@@ -13,8 +15,8 @@ export interface Display {
 }
 
 export interface RequestPayParams extends RequestPayAdditionalParams {
-  pg?: string;
-  pay_method?: string;
+  pg?: Pg;
+  pay_method?: PaymentMethod;
   escrow?: boolean;
   customer_uid?: string;
   merchant_uid: string;

--- a/RequestPayResponse.ts
+++ b/RequestPayResponse.ts
@@ -1,3 +1,6 @@
+import { PaymentMethod } from './PaymentMethod';
+import { Pg } from './Pg';
+
 export interface RequestPayAdditionalResponse {
   apply_num?: string;
   vbank_num?: string;
@@ -12,11 +15,11 @@ export interface RequestPayResponse extends RequestPayAdditionalResponse {
   error_msg?: string;
   imp_uid: string | null;
   merchant_uid: string;
-  pay_method?: string;
+  pay_method?: PaymentMethod;
   paid_amount?: number;
   status?: string;
   name?: string;
-  pg_provider?: string;
+  pg_provider?: Pg;
   pg_tid?: string;
   buyer_name?: string;
   buyer_email?: string;


### PR DESCRIPTION

https://github.com/junhoyeo/iamport-typings/assets/83825572/8085299b-2eaa-4be1-a096-b33e6f863ed6

`pg`, `pay_method` 속성에서 타입 추론을 받을 수 있도록 개선합니다.
`string & {}` 타입을 통해 라이브러리가 공식문서의 버저닝을 따라가지 못해도 임의의 문자열을 할당할 수 있도록 열어둡니다.