### PR TITLE
`RequestPayParams`에 파라미터 `channelKey` 추가

### DIFF
--- a/src/RequestPayParams.ts
+++ b/src/RequestPayParams.ts
@@ -37,6 +37,8 @@ export type Currency = 'KRW' | 'USD' | 'EUR' | 'JPY' | PayPalSupportedCurrency;
 export type Language = 'en' | 'ko' | 'zh';
 
 export interface RequestPayParams extends RequestPayAdditionalParams {
+  channelKey?: string;
+  
   /**
    * `pg`
    * - `PG사코드` 및 `PG사코드.{상점ID}` 형태로 지정할 수 있습니다.


### PR DESCRIPTION
안녕하세요
덕분에 typescript 환경에서 v1 SDK를 사용했습니다. 감사합니다.

포트원 v1 브라우저 SDK를 사용할 때 channelKey가 추가되었습니다.
우선 아래와 같이만 변경해도 사용은 가능한데, 추가적인 수정이 필요할거 같습니다.
https://developers.portone.io/sdk/ko/v1-sdk/javascript-sdk/payrq?v=v1